### PR TITLE
fix: Correct mock response format

### DIFF
--- a/ollama_chat_rag/mock_ollama.py
+++ b/ollama_chat_rag/mock_ollama.py
@@ -1,9 +1,9 @@
-from langchain_core.outputs import ChatGeneration, LLMResult
+from langchain_core.messages import AIMessage
 from langchain_core.pydantic_v1 import BaseModel
 
 class MockChatOllama(BaseModel):
-    def invoke(self, message: str):
-        return ChatGeneration(message=f"Mock response to: {message}")
+    def invoke(self, message: str, **kwargs):
+        return AIMessage(content=f"Mock response to: {message}")
 
     def __call__(self, *args, **kwargs):
         return self.invoke(*args, **kwargs)


### PR DESCRIPTION
This commit fixes a `ValidationError` that occurred when running the application in mock mode.

The `MockChatOllama` class was returning a `ChatGeneration` object containing a raw string, which is incorrect. The `invoke` method of a LangChain chat model should return a `BaseMessage` subclass, such as `AIMessage`.

The mock has been corrected to return an `AIMessage` with the response content, mimicking the behavior of the real `ChatOllama` class and satisfying the Pydantic model validation.