### PR TITLE
fix: Address deprecation warning and improve performance

### DIFF
--- a/ollama_chat_rag/requirements.txt
+++ b/ollama_chat_rag/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv
 ollama
 langchain
 langchain-community
+langchain-ollama
 typer[all]
 beautifulsoup4
 unstructured


### PR DESCRIPTION
This commit introduces two important fixes:

1.  **Resolves Deprecation Warning:** Updates the project to use the new `langchain-ollama` package instead of the deprecated `langchain-community` integration for `ChatOllama` and `OllamaEmbeddings`. The `requirements.txt` and all relevant imports in `main.py` have been updated accordingly.

2.  **Improves Performance and Fixes Hanging:** Implements an in-memory caching mechanism for expensive objects. `ChatOllama` clients and FAISS vector stores are now cached after their first creation and reused in subsequent requests. This prevents the costly operation of re-initializing the vector store for every RAG query, which was causing the application to hang.