### PR TITLE
feat: Add Cloudflare Tunnel deployment option

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,62 @@
+# Secure Deployment with Cloudflare Tunnel
+
+This guide provides step-by-step instructions on how to securely publish your API on the internet using [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/).
+
+This method is highly secure, as it does not expose your server's IP address directly and encrypts all traffic between Cloudflare and your server.
+
+## Prerequisites
+
+Before you begin, you will need:
+
+1.  **A Cloudflare Account:** You can create one for free at [cloudflare.com](https://www.cloudflare.com/).
+2.  **A Domain Name:** You need to own a domain name and have it added to your Cloudflare account.
+3.  **`cloudflared` Installed:** You must install the Cloudflare Tunnel command-line tool (`cloudflared`) on the machine where you will run the API.
+    -   Follow the official installation instructions here: [Install `cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/)
+
+## Deployment Steps
+
+### Step 1: Authenticate `cloudflared`
+
+First, you need to link the `cloudflared` tool to your Cloudflare account. Run the following command in your terminal:
+
+```bash
+cloudflared login
+```
+
+This will open a browser window asking you to log in to your Cloudflare account and authorize the tool for the domain you intend to use.
+
+### Step 2: Install Dependencies
+
+Make sure you have installed all the required Python packages, including the new `gunicorn` server:
+
+```bash
+pip install -r ollama_chat_rag/requirements.txt
+```
+
+### Step 3: Start the API Application
+
+Next, start the API in **production mode**. The following command uses `gunicorn` to run the application and puts it in the background so you can proceed to the next step.
+
+```bash
+python -m ollama_chat_rag.cli start --prod --background
+```
+
+You should see a message confirming that the application has started in the background. The API is now running locally, listening on `127.0.0.1:8000`.
+
+### Step 4: Launch the Cloudflare Tunnel
+
+Now, create the secure tunnel to expose your local API to the internet. Run the following command, but **make sure to replace `api.your-domain.com` with your desired public hostname**.
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:8000 --hostname api.your-domain.com
+```
+
+-   `--url http://127.0.0.1:8000`: This tells `cloudflared` to forward incoming traffic to your local API server.
+-   `--hostname api.your-domain.com`: This is the public URL where your API will be accessible. **You must change this to your own domain/subdomain.**
+
+`cloudflared` will now connect to the Cloudflare network. Once it's running, your API will be live and accessible at the hostname you specified, secured with HTTPS.
+
+## How to Stop Everything
+
+1.  **Stop the Tunnel:** Press `Ctrl+C` in the terminal where `cloudflared` is running.
+2.  **Stop the Application:** You need to find the background process and stop it. You can find the process ID (PID) with a command like `pgrep -f gunicorn` and then stop it with `kill <PID>`.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ python -m ollama_chat_rag.cli start
 
 The API will be available at `http://localhost:8000`.
 
+## Secure Deployment
+
+To securely publish this API on the internet, please follow the detailed instructions in the deployment guide:
+
+**[➡️ Secure Deployment Guide](./DEPLOYMENT.md)**
+
 ### Running in Mock Mode for Testing
 
 For development or testing purposes, you can run the server in a "mock" mode. In this mode, it does not connect to a real Ollama instance. Instead, it uses mock objects that return predictable, pre-defined responses.

--- a/ollama_chat_rag/cli.py
+++ b/ollama_chat_rag/cli.py
@@ -2,11 +2,30 @@ import typer
 import requests
 import uvicorn
 from multiprocessing import Process
+import subprocess
+import shlex
+import os
 
 app = typer.Typer()
 
-def run_app():
-    uvicorn.run("ollama_chat_rag.main:app", host="0.0.0.0", port=8000, reload=False)
+def run_app(prod: bool = False):
+    """Run the FastAPI application."""
+    if prod:
+        host = "127.0.0.1"
+        port = 8000
+        workers = (os.cpu_count() or 1) * 2 + 1
+        command = f"gunicorn -w {workers} -k uvicorn.workers.UvicornWorker --bind {host}:{port} ollama_chat_rag.main:app"
+
+        print(f"Starting production server with command: {command}")
+        try:
+            subprocess.run(shlex.split(command))
+        except FileNotFoundError:
+            print("\nError: 'gunicorn' command not found.")
+            print("Please install it with: pip install gunicorn")
+
+    else:
+        uvicorn.run("ollama_chat_rag.main:app", host="0.0.0.0", port=8000, reload=False)
+
 
 @app.command()
 def chat(message: str):
@@ -24,22 +43,31 @@ def rag(question: str):
     response = requests.post("http://localhost:8000/rag", json={"question": question})
     print(response.json()["response"])
 
-import os
-
 @app.command()
-def start(background: bool = typer.Option(False, "--background", "-b"), mock: bool = typer.Option(False, "--mock")):
+def start(
+    background: bool = typer.Option(False, "--background", "-b", help="Run the server in the background."),
+    mock: bool = typer.Option(False, "--mock", help="Use mock Ollama for testing."),
+    prod: bool = typer.Option(False, "--prod", help="Run in production mode with Gunicorn.")
+):
     """
     Start the FastAPI application.
+
+    In development mode (default), it uses Uvicorn and listens on 0.0.0.0:8000.
+    In production mode (--prod), it uses Gunicorn and listens on 127.0.0.1:8000.
     """
     if mock:
         os.environ["USE_MOCK_OLLAMA"] = "true"
 
+    # Use a lambda to pass the 'prod' argument to run_app
+    target_func = lambda: run_app(prod=prod)
+
     if background:
-        p = Process(target=run_app)
+        p = Process(target=target_func)
         p.start()
-        print("FastAPI application started in the background.")
+        mode = "production (Gunicorn)" if prod else "development (Uvicorn)"
+        print(f"FastAPI application started in the background in {mode} mode.")
     else:
-        run_app()
+        run_app(prod=prod)
 
 if __name__ == "__main__":
     app()

--- a/ollama_chat_rag/requirements.txt
+++ b/ollama_chat_rag/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn[standard]
+gunicorn
 python-dotenv
 ollama
 langchain


### PR DESCRIPTION
This change introduces a secure and simple deployment method using Cloudflare Tunnel, as requested by the user for personal and occasional use.

The key changes include:
- Adding `gunicorn` as a production-grade WSGI server.
- Updating the CLI (`cli.py`) with a `--prod` flag to launch the application with gunicorn, listening on localhost.
- Creating a comprehensive `DEPLOYMENT.md` guide with step-by-step instructions for setting up and running the Cloudflare Tunnel.
- Updating `README.md` to link to the new deployment documentation.