### PR TITLE
fix: Resolve multiprocessing pickling error on start

### DIFF
--- a/ollama_chat_rag/cli.py
+++ b/ollama_chat_rag/cli.py
@@ -58,11 +58,10 @@ def start(
     if mock:
         os.environ["USE_MOCK_OLLAMA"] = "true"
 
-    # Use a lambda to pass the 'prod' argument to run_app
-    target_func = lambda: run_app(prod=prod)
-
     if background:
-        p = Process(target=target_func)
+        # Pass run_app and its arguments directly to Process.
+        # This is compatible with multiprocessing on all platforms.
+        p = Process(target=run_app, args=(prod,))
         p.start()
         mode = "production (Gunicorn)" if prod else "development (Uvicorn)"
         print(f"FastAPI application started in the background in {mode} mode.")


### PR DESCRIPTION
This commit fixes a bug that occurred when starting the application in the background (`--background` flag).

The previous implementation used a lambda function as the target for `multiprocessing.Process`, which is not picklable and caused an `AttributeError` on Windows and other platforms that use the 'spawn' start method.

The fix replaces the lambda with the standard practice of passing the target function and its arguments separately to the `Process` constructor, e.g., `Process(target=run_app, args=(prod,))`. This resolves the pickling error.