### PR TITLE
feat: Add streaming support for API responses

### DIFF
--- a/ollama_chat_rag/.gitignore
+++ b/ollama_chat_rag/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 *.pyc
+*.log


### PR DESCRIPTION
This commit introduces streaming functionality to the `/v1/chat/completions` endpoint, making it compatible with the OpenAI Chat Completions API streaming format.

When a client sends a request with `"stream": true` in the JSON body, the server will now send back a stream of Server-Sent Events (SSE). Each event in the stream is a JSON object representing a chunk of the response, allowing for real-time display of the generated text.

Key changes:
- Modified the `ChatCompletionRequest` Pydantic model to include an optional `stream` boolean parameter.
- Updated the `chat_completions` endpoint to return a `StreamingResponse` when `stream` is true.
- Implemented an async generator `stream_generator` that leverages LangChain's `astream()` method for both `llm` and `rag` model types.
- Defined new Pydantic models (`ChatCompletionChunk`, `ChoiceChunk`, `ChoiceDelta`) to structure the streaming response chunks in an OpenAI-compatible format.
- Refactored the logging configuration to use `logging.basicConfig` for more reliable logging.
- Updated `.gitignore` to exclude log files from source control.